### PR TITLE
Fix readme to use public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Currently `RelayEnvironment` does not expose a way to inject a `CacheManager`, s
 ```js
 import CacheManager from 'relay-cache-manager';
 const cacheManager = new CacheManager();
-Relay.Store._storeData.injectCacheManager(cacheManager);
+Relay.Store.getStoreData().injectCacheManager(cacheManager);
 ```


### PR DESCRIPTION
Underscored methods are considered private and shouldn't be used - this replaces the access to the private `_storeData` with a call to the public `getStoreData()` method.