### PR TITLE
Add npmignore so npm doesn't use the gitignore for publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+# add npmignore so that npm doesn't use the gitignore for publishing


### PR DESCRIPTION
#### Overview

The current gitignore filters out the `lib` directory, and npm uses the `gitignore` as an `npmignore` if no `npmignore` file is present. At least in my fork/build system, that was causing published packages to break. I added a blank `npmignore` so that the `lib` directory is included in the package again.